### PR TITLE
fix: mobile responsive improvements — tap detection, touch scroll, canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,29 +726,20 @@ canvas.addEventListener('click', function(e) {
   const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen' || recentTouch;
   const rect = this.getBoundingClientRect();
 
-  // Use raw viewport-relative coordinates — no scaling needed since
-  // Chart.js getPixelForValue() also returns viewport-relative CSS pixels
   const canvasY = e.clientY - rect.top;
   const canvasX = e.clientX - rect.left;
 
-  // Find which GPU row was tapped by matching Y to each row's pixel position
-  const yAxis = chart.scales.y;
-  let tappedIdx = -1;
-  for (let i = 0; i < labels.length; i++) {
-    const tickY = yAxis.getPixelForValue(i);
-    if (Math.abs(canvasY - tickY) < ROW_HEIGHT / 2) {
-      tappedIdx = i;
-      break;
-    }
-  }
+  // Calculate row index directly from chart area — no scale API, pure math
+  const chartTop    = chart.chartArea.top;
+  const chartBottom = chart.chartArea.bottom;
+  const rowH        = (chartBottom - chartTop) / labels.length;
+  const tappedIdx   = Math.floor((canvasY - chartTop) / rowH);
 
-  if (tappedIdx === -1) return;
+  if (tappedIdx < 0 || tappedIdx >= labels.length) return;
 
   if (!isTouch) {
-    // Desktop — single click navigates
     if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
   } else {
-    // Mobile — first tap shows tooltip, second tap navigates
     const now = Date.now();
     if (tappedIdx === lastTappedIndex && now - lastTapTime < 2000) {
       if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');

--- a/index.html
+++ b/index.html
@@ -724,50 +724,39 @@ let lastTapTime = 0;
 
 canvas.addEventListener('click', function(e) {
   const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen' || recentTouch;
+  const rect = this.getBoundingClientRect();
 
-  // For hit detection, account for canvas scroll offset and DPR scaling
-  const scrollWrap = canvas.closest('.chart-scroll-wrap') || canvas.parentElement;
-  const rect = canvas.getBoundingClientRect();
-  
-  // Canvas logical coordinates (accounting for scrolled container)
-  const scaleX = (logicalWidth * dpr) / rect.width;
-  const scaleY = (CHART_HEIGHT * dpr) / rect.height;
-  const canvasX = (e.clientX - rect.left) * scaleX / dpr;
-  const canvasY = (e.clientY - rect.top)  * scaleY / dpr;
+  // Convert click to logical canvas coordinates
+  const canvasY = (e.clientY - rect.top) * (CHART_HEIGHT / rect.height);
+  const canvasX = (e.clientX - rect.left) * (logicalWidth / rect.width);
 
-  // Get elements using corrected coordinates
-  const elements = chart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, false);
-
-  if (elements.length === 0) {
-    // Label area — desktop only
-    if (!isTouch) {
-      const yAxis = chart.scales.y;
-      if (canvasX < yAxis.right) {
-        for (let i = 0; i < labels.length; i++) {
-          const tickY = yAxis.getPixelForValue(i);
-          if (Math.abs(canvasY - tickY) < 11 && links[i]) {
-            window.open(links[i], '_blank');
-            return;
-          }
-        }
-      }
+  // Find which GPU row was tapped using y-axis scale
+  const yAxis = chart.scales.y;
+  let tappedIdx = -1;
+  for (let i = 0; i < labels.length; i++) {
+    const tickY = yAxis.getPixelForValue(i);
+    if (Math.abs(canvasY - tickY) < ROW_HEIGHT / 2) {
+      tappedIdx = i;
+      break;
     }
-    return;
   }
 
-  const idx = elements[0].index;
+  if (tappedIdx === -1) return;
 
   if (!isTouch) {
     // Desktop — single click navigates
-    if (links[idx]) window.open(links[idx], '_blank');
+    if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
   } else {
     // Mobile — first tap shows tooltip, second tap navigates
     const now = Date.now();
-    if (idx === lastTappedIndex && now - lastTapTime < 2000) {
-      if (links[idx]) window.open(links[idx], '_blank');
+    if (tappedIdx === lastTappedIndex && now - lastTapTime < 2000) {
+      if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
       lastTappedIndex = -1;
     } else {
-      lastTappedIndex = idx;
+      // Manually trigger tooltip at this position
+      chart.tooltip.setActiveElements([{ datasetIndex: 0, index: tappedIdx }], { x: canvasX, y: canvasY });
+      chart.update();
+      lastTappedIndex = tappedIdx;
       lastTapTime = now;
     }
   }

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
 <meta property="og:title" content="SiliconValueIndex — GPU Value Rankings">
 <meta property="og:description" content="59 GPUs ranked by cost per FPS at 1440p Ultra. Find the best value GPU for your build.">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
@@ -463,6 +461,7 @@ canvas { -webkit-tap-highlight-color: transparent; }
     -webkit-overflow-scrolling: touch;
     margin: 0 -16px;
     padding: 0;
+    touch-action: pan-x; /* single finger scrolls horizontally, vertical goes to page */
   }
   .chart-panel {
     min-width: 960px;
@@ -549,7 +548,7 @@ canvas { -webkit-tap-highlight-color: transparent; }
         <div class="vleg"><div class="vdot" style="background:#0071C5"></div>Intel</div>
       </div>
     </div>
-    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing &nbsp;·&nbsp; <span style="color:#58a6ff;cursor:pointer" onclick="chart.resetZoom()">Reset zoom ↺</span></div>
+    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing</div>
     <canvas id="chart"></canvas>
   </div><!-- /chart-panel -->
   </div><!-- /chart-scroll-wrap -->
@@ -674,14 +673,6 @@ const chart = new Chart(ctx, {
     layout: { padding: { left: 8, right: 48, top: 4, bottom: 4 } },
     plugins: {
       legend: { display: false },
-      zoom: {
-        zoom: {
-          pinch: { enabled: true },
-          wheel: { enabled: false },
-          mode: 'y',
-        },
-        pan: { enabled: false }, // keep native single-finger scroll
-      },
       tooltip: {
         position: 'tap',
         backgroundColor: '#161b22', borderColor: '#21262d', borderWidth: 1,

--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@ footer a:hover { color: var(--accent); }
     padding: 0;
   }
   .chart-panel {
-    min-width: 800px;
+    min-width: 960px;
     border-radius: 0;
     border-left: none;
     border-right: none;
@@ -616,12 +616,12 @@ function barColor(cpf, vendor) {
 const colors = values.map((v, i) => barColor(v, vendors[i]));
 
 const dpr = window.devicePixelRatio || 1;
-const ROW_HEIGHT   = 22;
+const ROW_HEIGHT   = 26;
 const CHART_HEIGHT = labels.length * ROW_HEIGHT + 60;
 const canvas  = document.getElementById('chart');
 const wrapper = canvas.parentElement;
 
-const MOBILE_MIN = 800;
+const MOBILE_MIN = 960;
 const logicalWidth = Math.max(wrapper.clientWidth, MOBILE_MIN);
 canvas.style.width   = logicalWidth + 'px';
 canvas.style.height  = CHART_HEIGHT + 'px';
@@ -630,7 +630,9 @@ wrapper.style.paddingBottom = '24px';
 canvas.width  = logicalWidth * dpr;
 canvas.height = CHART_HEIGHT * dpr;
 const ctx = canvas.getContext('2d');
-ctx.scale(dpr, dpr);
+// Do NOT ctx.scale() here — Chart.js handles DPR via devicePixelRatio option below
+const fps    = [59.4,54.7,60.6,56.0,42.6,69.7,62.8,86.9,92.0,98.3,45.7,69.0,81.2,116.9,35.3,60.6,56.0,32.1,82.7,76.6,47.4,43.9,51.6,35.0,55.6,58.7,109.3,101.2,88.1,68.5,34.5,41.9,73.1,111.7,47.2,64.4,41.7,103.7,55.3,47.9,37.1,103.8,39.7,40.9,40.5,50.9,62.6,19.5,40.8,42.5,38.9,38.5,37.4,36.2,34.7,28.7,14.3,28.5,26.5];
+const prices = [345.99,325.00,399.99,379.99,289.99,499.00,449.99,629.99,679.99,729.99,349.99,549.99,649.99,943.77,299.00,519.99,494.99,289.99,762.99,735.00,459.99,429.99,512.99,349.99,562.99,603.99,1135.49,1059.99,937.99,733.99,372.99,452.55,813.04,1249.99,533.25,729.99,499.99,1283.31,722.99,638.99,506.86,1499.99,594.00,616.13,615.99,775.49,980.63,306.73,644.99,693.96,647.52,662.91,646.59,624.55,641.99,579.99,359.99,504.99,719.99];
 
 const zonePlugin = {
   id: 'zones',
@@ -663,7 +665,7 @@ const chart = new Chart(ctx, {
     maintainAspectRatio: false,
     devicePixelRatio: dpr,
     animation: { duration: 700, easing: 'easeOutQuart' },
-    layout: { padding: { left: 8, right: 36, top: 4, bottom: 4 } },
+    layout: { padding: { left: 8, right: 48, top: 4, bottom: 4 } },
     plugins: {
       legend: { display: false },
       tooltip: {
@@ -675,9 +677,16 @@ const chart = new Chart(ctx, {
         callbacks: {
           title: ctx => ctx[0].label,
           label: ctx => {
+            const i   = ctx.dataIndex;
             const cpf = ctx.parsed.x;
             const zone = cpf < 8 ? '✓ GREAT VALUE' : cpf < 12 ? '~ FAIR VALUE' : '✗ POOR VALUE';
-            return [`$${cpf.toFixed(2)} per FPS  ·  ${zone}`, 'Click to view on Newegg →'];
+            return [
+              `${zone}`,
+              `$/FPS:  $${cpf.toFixed(2)}`,
+              `FPS:    ${fps[i]}`,
+              `Price:  $${prices[i].toFixed(0)}`,
+              `→ Tap again to open Newegg`
+            ];
           }
         }
       }
@@ -686,15 +695,15 @@ const chart = new Chart(ctx, {
       x: {
         min: 0, max: 29,
         grid: { color: '#21262d', lineWidth: 0.8 },
-        ticks: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 11 }, callback: v => `$${v}` },
-        title: { display: true, text: 'Cost Per FPS ($/FPS) — Lower is Better', color: '#8b949e', font: { family: 'JetBrains Mono', size: 11 }, padding: { top: 10 } },
+        ticks: { color: '#8b949e', font: { family: 'JetBrains Mono', size: 13 }, callback: v => `$${v}` },
+        title: { display: true, text: 'Cost Per FPS ($/FPS) — Lower is Better', color: '#8b949e', font: { family: 'JetBrains Mono', size: 12 }, padding: { top: 10 } },
         border: { color: '#21262d' }
       },
       y: {
         grid: { display: false },
         border: { color: '#21262d' },
-        afterFit(scale) { scale.width = 155; },
-        ticks: { color: '#58a6ff', font: { family: 'JetBrains Mono', size: 11 }, autoSkip: false, maxRotation: 0, padding: 8 }
+        afterFit(scale) { scale.width = 170; },
+        ticks: { color: '#58a6ff', font: { family: 'JetBrains Mono', size: 13 }, autoSkip: false, maxRotation: 0, padding: 8 }
       }
     },
     onClick(event, elements) {
@@ -710,18 +719,54 @@ const chart = new Chart(ctx, {
   plugins: [zonePlugin]
 });
 
+// Desktop: click navigates directly
+// Mobile: first tap = tooltip, second tap = navigate
+// Detect if last interaction was touch (reliable across DevTools + real devices)
+let lastInteractionWasTouch = false;
+canvas.addEventListener('touchstart', () => { lastInteractionWasTouch = true; }, { passive: true });
+canvas.addEventListener('mousemove', () => { lastInteractionWasTouch = false; }, { passive: true });
+
+const isTouchDevice = () => lastInteractionWasTouch;
+let lastTappedIndex = -1;
+let lastTapTime = 0;
+
 canvas.addEventListener('click', function(e) {
-  const rect = this.getBoundingClientRect();
-  const clickX = e.clientX - rect.left;
-  const yAxis = chart.scales.y;
-  if (clickX < yAxis.right) {
+  const elements = chart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, false);
+
+  // Label area click (desktop only)
+  if (elements.length === 0 && !isTouchDevice()) {
+    const rect = this.getBoundingClientRect();
+    const clickX = e.clientX - rect.left;
     const clickY = e.clientY - rect.top;
-    for (let i = 0; i < labels.length; i++) {
-      const tickY = yAxis.getPixelForValue(i);
-      if (Math.abs(clickY - tickY) < 11 && links[i]) {
-        window.open(links[i], '_blank');
-        break;
+    const yAxis = chart.scales.y;
+    if (clickX < yAxis.right) {
+      for (let i = 0; i < labels.length; i++) {
+        const tickY = yAxis.getPixelForValue(i);
+        if (Math.abs(clickY - tickY) < 11 && links[i]) {
+          window.open(links[i], '_blank');
+          return;
+        }
       }
+    }
+    return;
+  }
+
+  if (elements.length === 0) return;
+  const idx = elements[0].index;
+
+  if (!isTouchDevice()) {
+    // Desktop — navigate immediately
+    if (links[idx]) window.open(links[idx], '_blank');
+  } else {
+    // Mobile — first tap shows tooltip (Chart.js handles that),
+    // second tap on same bar within 2s navigates
+    const now = Date.now();
+    if (idx === lastTappedIndex && now - lastTapTime < 2000) {
+      if (links[idx]) window.open(links[idx], '_blank');
+      lastTappedIndex = -1;
+    } else {
+      lastTappedIndex = idx;
+      lastTapTime = now;
     }
   }
 });

--- a/index.html
+++ b/index.html
@@ -615,22 +615,21 @@ function barColor(cpf, vendor) {
 }
 const colors = values.map((v, i) => barColor(v, vendors[i]));
 
-const dpr = Math.min(window.devicePixelRatio || 1, 2); // cap at 2x — 3x crashes mobile
+const dpr = Math.min(window.devicePixelRatio || 1, 2);
 const ROW_HEIGHT   = 26;
 const CHART_HEIGHT = labels.length * ROW_HEIGHT + 60;
 const canvas  = document.getElementById('chart');
 const wrapper = canvas.parentElement;
 
+// Set dimensions via CSS only — Chart.js reads these and owns the canvas pixel dimensions
 const MOBILE_MIN = window.innerWidth < 768 ? 700 : 960;
 const logicalWidth = Math.max(wrapper.clientWidth, MOBILE_MIN);
 canvas.style.width   = logicalWidth + 'px';
 canvas.style.height  = CHART_HEIGHT + 'px';
 wrapper.style.paddingBottom = '24px';
 
-canvas.width  = logicalWidth * dpr;
-canvas.height = CHART_HEIGHT * dpr;
+// DO NOT set canvas.width/height manually — let Chart.js do it via responsive sizing
 const ctx = canvas.getContext('2d');
-// Do NOT ctx.scale() here — Chart.js handles DPR via devicePixelRatio option below
 const fps    = [59.4,54.7,60.6,56.0,42.6,69.7,62.8,86.9,92.0,98.3,45.7,69.0,81.2,116.9,35.3,60.6,56.0,32.1,82.7,76.6,47.4,43.9,51.6,35.0,55.6,58.7,109.3,101.2,88.1,68.5,34.5,41.9,73.1,111.7,47.2,64.4,41.7,103.7,55.3,47.9,37.1,103.8,39.7,40.9,40.5,50.9,62.6,19.5,40.8,42.5,38.9,38.5,37.4,36.2,34.7,28.7,14.3,28.5,26.5];
 const prices = [345.99,325.00,399.99,379.99,289.99,499.00,449.99,629.99,679.99,729.99,349.99,549.99,649.99,943.77,299.00,519.99,494.99,289.99,762.99,735.00,459.99,429.99,512.99,349.99,562.99,603.99,1135.49,1059.99,937.99,733.99,372.99,452.55,813.04,1249.99,533.25,729.99,499.99,1283.31,722.99,638.99,506.86,1499.99,594.00,616.13,615.99,775.49,980.63,306.73,644.99,693.96,647.52,662.91,646.59,624.55,641.99,579.99,359.99,504.99,719.99];
 
@@ -663,7 +662,6 @@ const chart = new Chart(ctx, {
     indexAxis: 'y',
     responsive: false,
     maintainAspectRatio: false,
-    devicePixelRatio: dpr,
     animation: { duration: 700, easing: 'easeOutQuart' },
     layout: { padding: { left: 8, right: 48, top: 4, bottom: 4 } },
     plugins: {
@@ -724,30 +722,23 @@ let lastTapTime = 0;
 
 canvas.addEventListener('click', function(e) {
   const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen' || recentTouch;
-  const rect = this.getBoundingClientRect();
 
-  const canvasY = e.clientY - rect.top;
-  const canvasX = e.clientX - rect.left;
-
-  // Calculate row index directly from chart area — no scale API, pure math
-  const chartTop    = chart.chartArea.top;
-  const chartBottom = chart.chartArea.bottom;
-  const rowH        = (chartBottom - chartTop) / labels.length;
-  const tappedIdx   = Math.floor((canvasY - chartTop) / rowH);
-
-  if (tappedIdx < 0 || tappedIdx >= labels.length) return;
+  // Chart.js owns the coordinate system so getElementsAtEventForMode is accurate
+  const elements = chart.getElementsAtEventForMode(e, 'nearest', { intersect: false }, false);
+  if (elements.length === 0) return;
+  const idx = elements[0].index;
 
   if (!isTouch) {
-    if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
+    // Desktop — single click navigates
+    if (links[idx]) window.open(links[idx], '_blank');
   } else {
+    // Mobile — first tap shows tooltip, second tap within 2s navigates
     const now = Date.now();
-    if (tappedIdx === lastTappedIndex && now - lastTapTime < 2000) {
-      if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
+    if (idx === lastTappedIndex && now - lastTapTime < 2000) {
+      if (links[idx]) window.open(links[idx], '_blank');
       lastTappedIndex = -1;
     } else {
-      chart.tooltip.setActiveElements([{ datasetIndex: 0, index: tappedIdx }], { x: canvasX, y: canvasY });
-      chart.update();
-      lastTappedIndex = tappedIdx;
+      lastTappedIndex = idx;
       lastTapTime = now;
     }
   }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 <meta property="og:title" content="SiliconValueIndex — GPU Value Rankings">
 <meta property="og:description" content="59 GPUs ranked by cost per FPS at 1440p Ultra. Find the best value GPU for your build.">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-zoom/2.0.1/chartjs-plugin-zoom.min.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
@@ -547,7 +549,7 @@ canvas { -webkit-tap-highlight-color: transparent; }
         <div class="vleg"><div class="vdot" style="background:#0071C5"></div>Intel</div>
       </div>
     </div>
-    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing</div>
+    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing &nbsp;·&nbsp; <span style="cursor:pointer" onclick="chart.resetZoom()">Reset zoom ↺</span></div>
     <canvas id="chart"></canvas>
   </div><!-- /chart-panel -->
   </div><!-- /chart-scroll-wrap -->
@@ -665,6 +667,20 @@ const chart = new Chart(ctx, {
     animation: { duration: 700, easing: 'easeOutQuart' },
     layout: { padding: { left: 8, right: 48, top: 4, bottom: 4 } },
     plugins: {
+      zoom: {
+          zoom: {
+            wheel: { enabled: true },
+            pinch: { enabled: true },
+            mode: 'y',
+          },
+          pan: {
+            enabled: true,
+            mode: 'y',
+          },
+          limits: {
+            y: { min: 'original', max: 'original', minRange: 5 }
+          }
+        },
       legend: { display: false },
       tooltip: {
         backgroundColor: '#161b22', borderColor: '#21262d', borderWidth: 1,

--- a/index.html
+++ b/index.html
@@ -726,11 +726,12 @@ canvas.addEventListener('click', function(e) {
   const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen' || recentTouch;
   const rect = this.getBoundingClientRect();
 
-  // Convert click to logical canvas coordinates
-  const canvasY = (e.clientY - rect.top) * (CHART_HEIGHT / rect.height);
-  const canvasX = (e.clientX - rect.left) * (logicalWidth / rect.width);
+  // Use raw viewport-relative coordinates — no scaling needed since
+  // Chart.js getPixelForValue() also returns viewport-relative CSS pixels
+  const canvasY = e.clientY - rect.top;
+  const canvasX = e.clientX - rect.left;
 
-  // Find which GPU row was tapped using y-axis scale
+  // Find which GPU row was tapped by matching Y to each row's pixel position
   const yAxis = chart.scales.y;
   let tappedIdx = -1;
   for (let i = 0; i < labels.length; i++) {
@@ -753,7 +754,6 @@ canvas.addEventListener('click', function(e) {
       if (links[tappedIdx]) window.open(links[tappedIdx], '_blank');
       lastTappedIndex = -1;
     } else {
-      // Manually trigger tooltip at this position
       chart.tooltip.setActiveElements([{ datasetIndex: 0, index: tappedIdx }], { x: canvasX, y: canvasY });
       chart.update();
       lastTappedIndex = tappedIdx;

--- a/index.html
+++ b/index.html
@@ -434,7 +434,7 @@ footer a:hover { color: var(--accent); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
-.hero-tag  { animation: fadeUp 0.5s ease both; }
+canvas { -webkit-tap-highlight-color: transparent; }
 .hero h1   { animation: fadeUp 0.5s 0.1s ease both; }
 .hero-sub  { animation: fadeUp 0.5s 0.2s ease both; }
 .stat-bar  { animation: fadeUp 0.5s 0.3s ease both; }
@@ -715,13 +715,15 @@ const chart = new Chart(ctx, {
 
 // Desktop: click navigates directly
 // Mobile: first tap = tooltip, second tap = navigate
-// Reliable touch vs mouse detection using pointerType
-// Remove old touchstart/mousemove listeners — pointerType handles it natively
+// Track touch separately as pointerType can be unreliable on some Android versions
+let recentTouch = false;
+canvas.addEventListener('touchend', () => { recentTouch = true; setTimeout(() => { recentTouch = false; }, 500); }, { passive: true });
+
 let lastTappedIndex = -1;
 let lastTapTime = 0;
 
 canvas.addEventListener('click', function(e) {
-  const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen';
+  const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen' || recentTouch;
 
   // For hit detection, account for canvas scroll offset and DPR scaling
   const scrollWrap = canvas.closest('.chart-scroll-wrap') || canvas.parentElement;

--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@ canvas { -webkit-tap-highlight-color: transparent; }
         <div class="vleg"><div class="vdot" style="background:#0071C5"></div>Intel</div>
       </div>
     </div>
-    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing &nbsp;·&nbsp; <span style="cursor:pointer" onclick="chart.resetZoom()">Reset zoom ↺</span></div>
+    <div class="click-hint">Click a <span>GPU name</span> or bar to open its Newegg listing &nbsp;·&nbsp; <span style="color:#58a6ff;cursor:pointer" onclick="chart.resetZoom()">Reset zoom ↺</span></div>
     <canvas id="chart"></canvas>
   </div><!-- /chart-panel -->
   </div><!-- /chart-scroll-wrap -->
@@ -618,6 +618,7 @@ function barColor(cpf, vendor) {
 const colors = values.map((v, i) => barColor(v, vendors[i]));
 
 const dpr = Math.min(window.devicePixelRatio || 1, 2);
+const isMobile = window.innerWidth < 768;
 const ROW_HEIGHT   = 26;
 const CHART_HEIGHT = labels.length * ROW_HEIGHT + 60;
 const canvas  = document.getElementById('chart');
@@ -634,6 +635,11 @@ wrapper.style.paddingBottom = '24px';
 const ctx = canvas.getContext('2d');
 const fps    = [59.4,54.7,60.6,56.0,42.6,69.7,62.8,86.9,92.0,98.3,45.7,69.0,81.2,116.9,35.3,60.6,56.0,32.1,82.7,76.6,47.4,43.9,51.6,35.0,55.6,58.7,109.3,101.2,88.1,68.5,34.5,41.9,73.1,111.7,47.2,64.4,41.7,103.7,55.3,47.9,37.1,103.8,39.7,40.9,40.5,50.9,62.6,19.5,40.8,42.5,38.9,38.5,37.4,36.2,34.7,28.7,14.3,28.5,26.5];
 const prices = [345.99,325.00,399.99,379.99,289.99,499.00,449.99,629.99,679.99,729.99,349.99,549.99,649.99,943.77,299.00,519.99,494.99,289.99,762.99,735.00,459.99,429.99,512.99,349.99,562.99,603.99,1135.49,1059.99,937.99,733.99,372.99,452.55,813.04,1249.99,533.25,729.99,499.99,1283.31,722.99,638.99,506.86,1499.99,594.00,616.13,615.99,775.49,980.63,306.73,644.99,693.96,647.52,662.91,646.59,624.55,641.99,579.99,359.99,504.99,719.99];
+
+// Tooltip appears where user taps, not at bar end
+Chart.Tooltip.positioners.tap = function(elements, eventPosition) {
+  return { x: eventPosition.x, y: eventPosition.y };
+};
 
 const zonePlugin = {
   id: 'zones',
@@ -667,22 +673,17 @@ const chart = new Chart(ctx, {
     animation: { duration: 700, easing: 'easeOutQuart' },
     layout: { padding: { left: 8, right: 48, top: 4, bottom: 4 } },
     plugins: {
-      zoom: {
-          zoom: {
-            wheel: { enabled: true },
-            pinch: { enabled: true },
-            mode: 'y',
-          },
-          pan: {
-            enabled: true,
-            mode: 'y',
-          },
-          limits: {
-            y: { min: 'original', max: 'original', minRange: 5 }
-          }
-        },
       legend: { display: false },
+      zoom: {
+        zoom: {
+          pinch: { enabled: true },
+          wheel: { enabled: false },
+          mode: 'y',
+        },
+        pan: { enabled: false }, // keep native single-finger scroll
+      },
       tooltip: {
+        position: 'tap',
         backgroundColor: '#161b22', borderColor: '#21262d', borderWidth: 1,
         titleColor: '#e6edf3', bodyColor: '#8b949e',
         titleFont: { family: 'JetBrains Mono', size: 13, weight: '600' },

--- a/index.html
+++ b/index.html
@@ -706,12 +706,6 @@ const chart = new Chart(ctx, {
         ticks: { color: '#58a6ff', font: { family: 'JetBrains Mono', size: 13 }, autoSkip: false, maxRotation: 0, padding: 8 }
       }
     },
-    onClick(event, elements) {
-      if (elements.length > 0) {
-        const idx = elements[0].index;
-        if (links[idx]) window.open(links[idx], '_blank');
-      }
-    },
     onHover(event, elements) {
       event.native.target.style.cursor = elements.length > 0 ? 'pointer' : 'default';
     }
@@ -721,45 +715,51 @@ const chart = new Chart(ctx, {
 
 // Desktop: click navigates directly
 // Mobile: first tap = tooltip, second tap = navigate
-// Detect if last interaction was touch (reliable across DevTools + real devices)
-let lastInteractionWasTouch = false;
-canvas.addEventListener('touchstart', () => { lastInteractionWasTouch = true; }, { passive: true });
-canvas.addEventListener('mousemove', () => { lastInteractionWasTouch = false; }, { passive: true });
-
-const isTouchDevice = () => lastInteractionWasTouch;
+// Reliable touch vs mouse detection using pointerType
+// Remove old touchstart/mousemove listeners — pointerType handles it natively
 let lastTappedIndex = -1;
 let lastTapTime = 0;
 
 canvas.addEventListener('click', function(e) {
+  const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen';
+
+  // For hit detection, account for canvas scroll offset and DPR scaling
+  const scrollWrap = canvas.closest('.chart-scroll-wrap') || canvas.parentElement;
+  const rect = canvas.getBoundingClientRect();
+  
+  // Canvas logical coordinates (accounting for scrolled container)
+  const scaleX = (logicalWidth * dpr) / rect.width;
+  const scaleY = (CHART_HEIGHT * dpr) / rect.height;
+  const canvasX = (e.clientX - rect.left) * scaleX / dpr;
+  const canvasY = (e.clientY - rect.top)  * scaleY / dpr;
+
+  // Get elements using corrected coordinates
   const elements = chart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, false);
 
-  // Label area click (desktop only)
-  if (elements.length === 0 && !isTouchDevice()) {
-    const rect = this.getBoundingClientRect();
-    const clickX = e.clientX - rect.left;
-    const clickY = e.clientY - rect.top;
-    const yAxis = chart.scales.y;
-    if (clickX < yAxis.right) {
-      for (let i = 0; i < labels.length; i++) {
-        const tickY = yAxis.getPixelForValue(i);
-        if (Math.abs(clickY - tickY) < 11 && links[i]) {
-          window.open(links[i], '_blank');
-          return;
+  if (elements.length === 0) {
+    // Label area — desktop only
+    if (!isTouch) {
+      const yAxis = chart.scales.y;
+      if (canvasX < yAxis.right) {
+        for (let i = 0; i < labels.length; i++) {
+          const tickY = yAxis.getPixelForValue(i);
+          if (Math.abs(canvasY - tickY) < 11 && links[i]) {
+            window.open(links[i], '_blank');
+            return;
+          }
         }
       }
     }
     return;
   }
 
-  if (elements.length === 0) return;
   const idx = elements[0].index;
 
-  if (!isTouchDevice()) {
-    // Desktop — navigate immediately
+  if (!isTouch) {
+    // Desktop — single click navigates
     if (links[idx]) window.open(links[idx], '_blank');
   } else {
-    // Mobile — first tap shows tooltip (Chart.js handles that),
-    // second tap on same bar within 2s navigates
+    // Mobile — first tap shows tooltip, second tap navigates
     const now = Date.now();
     if (idx === lastTappedIndex && now - lastTapTime < 2000) {
       if (links[idx]) window.open(links[idx], '_blank');

--- a/index.html
+++ b/index.html
@@ -615,13 +615,13 @@ function barColor(cpf, vendor) {
 }
 const colors = values.map((v, i) => barColor(v, vendors[i]));
 
-const dpr = window.devicePixelRatio || 1;
+const dpr = Math.min(window.devicePixelRatio || 1, 2); // cap at 2x — 3x crashes mobile
 const ROW_HEIGHT   = 26;
 const CHART_HEIGHT = labels.length * ROW_HEIGHT + 60;
 const canvas  = document.getElementById('chart');
 const wrapper = canvas.parentElement;
 
-const MOBILE_MIN = 960;
+const MOBILE_MIN = window.innerWidth < 768 ? 700 : 960;
 const logicalWidth = Math.max(wrapper.clientWidth, MOBILE_MIN);
 canvas.style.width   = logicalWidth + 'px';
 canvas.style.height  = CHART_HEIGHT + 'px';


### PR DESCRIPTION
- Fix vertical tap offset on mobile using Chart.js hit detection
- First tap shows tooltip, second tap navigates to Newegg
- Remove blue tap highlight on canvas
- Horizontal single finger scroll on chart, vertical scroll passes to page
- Cap DPR at 2x to prevent out-of-memory crash on high-density screens
- Tooltip appears at tap position instead of bar end